### PR TITLE
Add README build and coverage badges, enable pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,31 @@
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+# Disallow approval of PRs still under development
+always_pending:
+  title_regex: 'WIP'
+  labels:
+    - do-not-merge
+    - wip
+  explanation: 'Work in progress - do not merge'
+
+group_defaults:
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:)'
+    reject_regex: '^(Rejected|-1|:-1:)'
+  reset_on_push:
+    enabled: false
+  reset_on_reopened:
+    enabled: false
+  author_approval:
+    ignored: true
+
+groups:
+  approvers:
+    required: 1
+    teams:
+      - proxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ install:
 
 script:
   - cd ${TRAVIS_BUILD_DIR} && make test
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all:
 	go build proxy.go
 
 test: all
-	go test -v
+	go test -v -race -coverprofile=coverage.txt -covermode=atomic
 
 clean:
 	rm -f proxy

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+[![Build Status](https://travis-ci.org/kata-containers/proxy.svg?branch=master)](https://travis-ci.org/kata-containers/proxy)
+[![codecov](https://codecov.io/gh/kata-containers/proxy/branch/master/graph/badge.svg)](https://codecov.io/gh/kata-containers/proxy)
+
+# Kata Containers Proxy


### PR DESCRIPTION
For travis build results and codecov coverage.

For pullapprove, the proxy team will be the PR gatekeepers.

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>