### PR TITLE
fix UT data race

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -9,7 +9,6 @@ package main
 
 import (
 	"crypto/md5"
-	"flag"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -23,8 +22,6 @@ import (
 
 func client(proxyAddr, file string) error {
 	buf := []byte("hello proxy")
-
-	flag.Parse()
 
 	conn, err := net.Dial("unix", proxyAddr)
 	if err != nil {


### PR DESCRIPTION
We do not need to parse flags for UT.

This should fix the CI failure in https://travis-ci.org/kata-containers/proxy/builds/308886984?utm_source=github_status&utm_medium=notification