### PR TITLE
error: Fix error formatting and improve message

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -15,8 +15,8 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/sirupsen/logrus"
 	"github.com/hashicorp/yamux"
+	"github.com/sirupsen/logrus"
 )
 
 func serve(servConn io.ReadWriteCloser, proto, addr string, results chan error) error {
@@ -135,7 +135,7 @@ func main() {
 	// yamux connection
 	servConn, err := net.Dial("unix", muxAddr)
 	if err != nil {
-		logrus.Fatal("fail to dial channel(%s): %s", muxAddr, err)
+		logrus.Fatalf("failed to dial channel(%q): %s", muxAddr, err)
 		return
 	}
 	defer servConn.Close()


### PR DESCRIPTION
Failing to dial the mux address would result in an incorrectly
formatted error message due to calling `logrus.Fail()` rather than
`logrus.Failf()`.

Also improved wording and quoted the address string.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>