### PR TITLE
Add version details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 proxy
+kata-proxy
 test/server
 test/client

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,14 @@
 TARGET = kata-proxy
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
+
 $(TARGET): $(SOURCES)
-	go build -o $@ proxy.go
+	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:
 	go test -v -race -coverprofile=coverage.txt -covermode=atomic

--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,9 @@
 #
 
 TARGET = kata-proxy
+SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
-all: $(TARGET)
-
-$(TARGET):
+$(TARGET): $(SOURCES)
 	go build -o $@ proxy.go
 
 test:

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,2 @@
+# This is the proxy version.
+0.0.1

--- a/proxy.go
+++ b/proxy.go
@@ -108,8 +108,7 @@ func unixAddr(uri string) (string, error) {
 	return addr.Host + addr.Path, nil
 }
 
-func setupLoger(logLevel string) error {
-
+func setupLogger(logLevel string) error {
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
@@ -140,7 +139,7 @@ func main() {
 		os.Exit(0)
 	}
 
-	err := setupLoger(logLevel)
+	err := setupLogger(logLevel)
 	if err != nil {
 		proxyLog.Fatal(err)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -10,6 +10,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -21,6 +22,9 @@ import (
 )
 
 const proxyName = "kata-proxy"
+
+// version is the proxy version. This variable is populated at build time.
+var version = "unknown"
 
 var proxyLog = logrus.WithFields(logrus.Fields{
 	"name": proxyName,
@@ -112,11 +116,17 @@ func setupLoger(logLevel string) error {
 	}
 
 	logrus.SetLevel(level)
+
+	proxyLog.WithField("version", version).Info()
+
 	return nil
 }
 
 func main() {
 	var channel, proxyAddr, logLevel string
+	var showVersion bool
+
+	flag.BoolVar(&showVersion, "version", false, "display program version and exit")
 	flag.StringVar(&channel, "mux-socket", "", "unix socket to multiplex on")
 	flag.StringVar(&proxyAddr, "listen-socket", "", "unix socket to listen on")
 
@@ -124,6 +134,11 @@ func main() {
 		"log messages above specified level: debug, warn, error, fatal or panic")
 
 	flag.Parse()
+
+	if showVersion {
+		fmt.Printf("%v version %v\n", proxyName, version)
+		os.Exit(0)
+	}
 
 	err := setupLoger(logLevel)
 	if err != nil {


### PR DESCRIPTION
build: Add version details to binary

Generate a version string containing version number and commit that the
proxy logs when initialising the logger or when the user specifies
"-version".
