### PR TITLE
CI: Enable centralised static checks

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+tests_repo="github.com/kata-containers/tests"
+tests_repo_dir="${GOPATH}/src/${tests_repo}"
+
+go get -d "$tests_repo" || true
+(cd "$tests_repo_dir" && bash ".ci/static-checks.sh")

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ go_import_path: github.com/kata-containers/proxy
 go:
   - 1.8
 
+before_script:
+  - ".ci/setup.sh"
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq automake


### PR DESCRIPTION
Run the static checks defined in the tests repository. Currently, this
just runs the `checkcommits` tool that requires all PRs to contain a
"Fixes #XXX" comment and a "Signed-off-by:" comment.

Fixes #16.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>