### PR TITLE
CI: Enable centralised static checks

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+export tests_repo="github.com/kata-containers/tests"
+export tests_repo_dir="$GOPATH/src/$tests_repo"
+
+clone_tests_repo()
+{
+	# KATA_CI_NO_NETWORK is (has to be) ignored if there is
+	# no existing clone.
+	if [ -d "$tests_repo_dir" -a -n "$KATA_CI_NO_NETWORK" ]
+	then
+		return
+	fi
+
+	go get -d -u "$tests_repo" || true
+}
+
+run_static_checks()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/static-checks.sh"
+}

--- a/.ci/static-checks.sh
+++ b/.ci/static-checks.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_static_checks

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ go_import_path: github.com/kata-containers/proxy
 go:
   - 1.8
 
+before_script:
+  - ".ci/static-checks.sh"
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y -qq automake

--- a/Makefile
+++ b/Makefile
@@ -27,3 +27,8 @@ clean:
 
 install:
 	install -D $(TARGET) $(LIBEXECDIR)/kata-containers/$(TARGET)
+
+check: check-go-static
+
+check-go-static:
+	bash .ci/static-checks.sh


### PR DESCRIPTION
Run the static checks defined in the tests repository. Currently, this
just runs the `checkcommits` tool that requires all PRs to contain a
"Fixes #XXX" comment and a "Signed-off-by:" comment.

Fixes #16.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>