### PR TITLE
makefile: Add "install" case

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+PREFIX := /usr
+LIBEXECDIR := $(PREFIX)/libexec
+
 TARGET = kata-proxy
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
 
@@ -21,3 +24,6 @@ test:
 
 clean:
 	rm -f $(TARGET)
+
+install:
+	install -D $(TARGET) $(LIBEXECDIR)/kata-containers/$(TARGET)


### PR DESCRIPTION
In order to install the kata-proxy binary from the Makefile, this
commit adds a new entry "install" to it.

Fixes #21

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>