### PR TITLE
logger: Fix syslog identifier.

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -122,7 +122,7 @@ func setupLogger(logLevel string) error {
 
 	proxyLog.SetLevel(level)
 
-	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, proxyName)
 	if err == nil {
 		proxyLog.AddHook(hook)
 	}


### PR DESCRIPTION
Ensure log entries specify the name of the proxy, not its path.

Fixes #28.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>