### PR TITLE
logger: Use nanosecond timestamps

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/yamux"
 	"github.com/sirupsen/logrus"
@@ -127,6 +128,8 @@ func setupLogger(logLevel string) error {
 	}
 
 	proxyLog.SetLevel(level)
+
+	proxyLog.Formatter = &logrus.TextFormatter{TimestampFormat: time.RFC3339Nano}
 
 	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, proxyName)
 	if err == nil {


### PR DESCRIPTION
Switch from second resolution to nanosecond resolution log entries.

Fixes #49.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>