### PR TITLE
logging: Add agent source log field

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -115,8 +115,9 @@ func unixAddr(uri string) (string, error) {
 
 func logger() *logrus.Entry {
 	return proxyLog.WithFields(logrus.Fields{
-		"name": proxyName,
-		"pid":  os.Getpid(),
+		"name":   proxyName,
+		"pid":    os.Getpid(),
+		"source": "proxy",
 	})
 }
 
@@ -168,10 +169,16 @@ func printAgentLogs(sock string) error {
 		return err
 	}
 
+	// Allow log messages coming from the agent to be distinguished from
+	// messages originating from the proxy itself.
+	agentLogger := logger().WithFields(logrus.Fields{
+		"source": "agent",
+	})
+
 	go func() {
 		scanner := bufio.NewScanner(conn)
 		for scanner.Scan() {
-			logger().Infof("%s\n", scanner.Text())
+			agentLogger.Infof("%s\n", scanner.Text())
 		}
 
 		if err := scanner.Err(); err != nil {

--- a/proxy.go
+++ b/proxy.go
@@ -309,4 +309,6 @@ func main() {
 		logger().Fatal(err)
 		return
 	}
+
+	logger().Debug("shutting down")
 }


### PR DESCRIPTION
Add a new "source" log field to allow logs coming from the agent to be
distinguished from logs coming direct from the proxy.

Fixes #51.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>