### PR TITLE
main: coredump on internal error

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -18,6 +18,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime/debug"
 	"sync"
 	"syscall"
 	"time"
@@ -229,6 +230,11 @@ func handleSignal(sigCh chan os.Signal, vmConn *net.Conn, proxyListener *net.Lis
 	}
 
 	return nil
+}
+
+func init() {
+	// Force coredump + full stacktrace on internal error
+	debug.SetTraceback("crash")
 }
 
 func main() {


### PR DESCRIPTION
Override the default golang panic handling by printing a full traceback
(not just for the current goroutine) and dumping core to allow
crash-handling programs to log the details.

Fixes #59.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>