### PR TITLE
ci: lib: allow override of tests_repo

### DIFF
--- a/.ci/lib.sh
+++ b/.ci/lib.sh
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-export tests_repo="github.com/kata-containers/tests"
+export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
 
 clone_tests_repo()


### PR DESCRIPTION
Only use the default tests_repo url if one is not already set.

Fixes: #64

Signed-off-by: Graham whaley <graham.whaley@intel.com>