### PR TITLE
ci: move go 1.10

### DIFF
--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -12,5 +12,7 @@ source "${cidir}/lib.sh"
 clone_tests_repo
 
 pushd "${tests_repo_dir}"
+sudo rm -rf /usr/local/go
+.ci/install_go.sh 1.10
 .ci/setup.sh
 popd


### PR DESCRIPTION
do no merge - only to check move to go 1.10 works

note: make issue number

Fixes: #1

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>