### PR TITLE
disable yamux keep alive

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -43,7 +43,10 @@ var crashOnError = false
 var proxyLog = logrus.New()
 
 func serve(servConn io.ReadWriteCloser, proto, addr string, results chan error) (net.Listener, error) {
-	session, err := yamux.Client(servConn, nil)
+	sessionConfig := yamux.DefaultConfig()
+	// Disable keepAlive since we don't know how much time a container can be paused
+	sessionConfig.EnableKeepAlive = false
+	session, err := yamux.Client(servConn, sessionConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We don't know how much time a container can be paused, hence connection
write timeout should be disabled to don't close the connection while
the container is paused.

fixes kata-containers/agent#231
fixes #70

Signed-off-by: Julio Montes <julio.montes@intel.com>