### PR TITLE
signal: Removed SIGSTKFLT

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,15 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-sudo: required
-dist: trusty
+os:
+  - linux
+  - osx
+
+matrix:
+  include:
+    - os: linux
+      sudo: required
+      dist: trusty
 
 language: go
 go_import_path: github.com/kata-containers/proxy
@@ -17,8 +24,8 @@ before_script:
   - ".ci/static-checks.sh"
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq automake
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make

--- a/signals.go
+++ b/signals.go
@@ -19,15 +19,14 @@ import (
 //
 // The value is true if receiving the signal should be fatal.
 var handledSignalsMap = map[syscall.Signal]bool{
-	syscall.SIGABRT:   true,
-	syscall.SIGBUS:    true,
-	syscall.SIGILL:    true,
-	syscall.SIGQUIT:   true,
-	syscall.SIGSEGV:   true,
-	syscall.SIGSTKFLT: true,
-	syscall.SIGSYS:    true,
-	syscall.SIGTRAP:   true,
-	syscall.SIGUSR1:   false,
+	syscall.SIGABRT: true,
+	syscall.SIGBUS:  true,
+	syscall.SIGILL:  true,
+	syscall.SIGQUIT: true,
+	syscall.SIGSEGV: true,
+	syscall.SIGSYS:  true,
+	syscall.SIGTRAP: true,
+	syscall.SIGUSR1: false,
 }
 
 func handlePanic() {


### PR DESCRIPTION
Fixes #75

According to the man 7 page on Linux the signal is not used. Further, it is not defined on Darwin.
This makes the build compile both on Linux and Darwin.