### PR TITLE
logging: Use WithError() for all errors

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -317,28 +317,30 @@ func realMain() {
 
 	if err := setupLogger(logLevel); err != nil {
 		logger().WithError(err).Fatal("unable to setup logger")
+		os.Exit(1)
 	}
 
 	if err := printAgentLogs(agentLogsSocket); err != nil {
 		logger().WithError(err).Fatal("failed to print agent logs")
-		return
+		os.Exit(1)
 	}
 
 	muxAddr, err := unixAddr(channel)
 	if err != nil {
 		logger().WithError(err).Fatal("invalid mux socket address")
+		os.Exit(1)
 	}
 	listenAddr, err := unixAddr(proxyAddr)
 	if err != nil {
 		logger().WithError(err).Fatal("invalid listen socket address")
-		return
+		os.Exit(1)
 	}
 
 	// yamux connection
 	servConn, err := net.Dial("unix", muxAddr)
 	if err != nil {
 		logger().WithError(err).WithField("channel", muxAddr).Fatal("failed to dial channel")
-		return
+		os.Exit(1)
 	}
 	defer func() {
 		if servConn != nil {
@@ -350,7 +352,7 @@ func realMain() {
 	l, err := serve(servConn, "unix", listenAddr, results)
 	if err != nil {
 		logger().WithError(err).Fatal("failed to serve")
-		return
+		os.Exit(1)
 	}
 	defer func() {
 		if l != nil {
@@ -368,6 +370,7 @@ func realMain() {
 
 	if err := handleExitSignal(sigCh, &servConn, &l); err != nil {
 		logger().WithError(err).Fatal("failed to handle exit signal")
+		os.Exit(1)
 	}
 
 	logger().Debug("shutting down")

--- a/proxy.go
+++ b/proxy.go
@@ -141,9 +141,11 @@ func setupLogger(logLevel string) error {
 	proxyLog.Formatter = &logrus.TextFormatter{TimestampFormat: time.RFC3339Nano}
 
 	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, proxyName)
-	if err == nil {
-		proxyLog.AddHook(hook)
+	if err != nil {
+		return err
 	}
+
+	proxyLog.AddHook(hook)
 
 	logger().WithField("version", version).Info()
 


### PR DESCRIPTION
Use the standard `logrus.WithError()` API to handle logging of all
errors.

Also, rather than just returning (or continuing in some cases), always `exit(1)` on fatal error to indicate failure.

Fixes #85.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
