### PR TITLE
logging: Add sandbox CLI option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make

--- a/proxy.go
+++ b/proxy.go
@@ -125,7 +125,7 @@ func logger() *logrus.Entry {
 	})
 }
 
-func setupLogger(logLevel string) error {
+func setupLogger(logLevel string, announceFields logrus.Fields) error {
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func setupLogger(logLevel string) error {
 
 	proxyLog.AddHook(hook)
 
-	logger().WithField("version", version).Info()
+	logger().WithFields(announceFields).WithField("log-level", logLevel).Info("announce")
 
 	return nil
 }
@@ -312,7 +312,15 @@ func realMain() {
 
 	sigCh := setupNotifier()
 
-	if err := setupLogger(logLevel); err != nil {
+	announceFields := logrus.Fields{
+		"agent-logs-socket":   agentLogsSocket,
+		"channel-mux-socket":  channel,
+		"debug":               debug,
+		"proxy-listen-socket": proxyAddr,
+		"version":             version,
+	}
+
+	if err := setupLogger(logLevel, announceFields); err != nil {
 		logger().WithError(err).Fatal("unable to setup logger")
 		os.Exit(1)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -40,6 +40,11 @@ var version = "unknown"
 // if true, coredump when an internal error occurs or a fatal signal is received
 var crashOnError = false
 
+// Name of sandbox this proxy instance is communicating with. This is not
+// required by the proxy itself - it is added to all log entries to make log
+// analysis easier.
+var sandboxID string
+
 var proxyLog = logrus.New()
 
 func serve(servConn io.ReadWriteCloser, proto, addr string, results chan error) (net.Listener, error) {
@@ -118,11 +123,17 @@ func unixAddr(uri string) (string, error) {
 }
 
 func logger() *logrus.Entry {
-	return proxyLog.WithFields(logrus.Fields{
+	fields := logrus.Fields{
 		"name":   proxyName,
 		"pid":    os.Getpid(),
 		"source": "proxy",
-	})
+	}
+
+	if sandboxID != "" {
+		fields["sandbox"] = sandboxID
+	}
+
+	return proxyLog.WithFields(fields)
 }
 
 func setupLogger(logLevel string, announceFields logrus.Fields) error {
@@ -292,6 +303,7 @@ func realMain() {
 	flag.StringVar(&channel, "mux-socket", "", "unix socket to multiplex on")
 	flag.StringVar(&proxyAddr, "listen-socket", "", "unix socket to listen on")
 	flag.StringVar(&agentLogsSocket, "agent-logs-socket", "", "socket to listen on to retrieve agent logs")
+	flag.StringVar(&sandboxID, "sandbox", "", "sandbox ID the proxy is connecting to (used for logging only)")
 
 	flag.StringVar(&logLevel, "log", "warn",
 		"log messages above specified level: debug, warn, error, fatal or panic")


### PR DESCRIPTION
Added a new `-sandbox` command-line option. This is not required by the
proxy itself, but is used to add a `sandbox` log field to make log
analysis easier.

Also changed the initial log message to show the standard "announce" message tag along with fields for each of the command-line options.

Fixes #87.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
