### PR TITLE
CI: Install yq on darwin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ before_script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash yq; fi
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make


### PR DESCRIPTION
The osx build needs the `yq` command.

Fixes #95.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>