### PR TITLE
logging: Fix incorrect logger usage

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -130,7 +130,7 @@ func proxyConn(conn1 net.Conn, conn2 net.Conn, wg *sync.WaitGroup) {
 	copyStream := func(dst io.Writer, src io.Reader) {
 		_, err := io.Copy(dst, src)
 		if err != nil {
-			logger().Debug("Copy stream error: %v", err)
+			logger().WithError(err).Debug("Copy stream error")
 		}
 
 		once.Do(cleanup)


### PR DESCRIPTION
Correct an invalid use of the logger where an argument was passed to
`Debug()` (should have been `Debugf()`) by using of `WithError()`
instead.

Fixes #98.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>