### PR TITLE
Stable 1.1.1 candidate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ before_script:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq              ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y -qq automake ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install bash; fi
 
 install:
   - cd ${TRAVIS_BUILD_DIR} && make

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-PREFIX := /usr
-LIBEXECDIR := $(PREFIX)/libexec
+DESTDIR :=
+PREFIX := usr
+LIBEXECDIR := libexec
+PROJECT := kata-containers
+# Override will ignore PREFIX, LIBEXECDIR and PROJECT
+INSTALLDIR := /$(PREFIX)/$(LIBEXECDIR)/$(PROJECT)
 
 TARGET = kata-proxy
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')
@@ -26,7 +30,7 @@ clean:
 	rm -f $(TARGET)
 
 install:
-	install -D $(TARGET) $(LIBEXECDIR)/kata-containers/$(TARGET)
+	install -D $(TARGET) $(DESTDIR)/$(INSTALLDIR)/$(TARGET)
 
 check: check-go-static
 

--- a/proxy.go
+++ b/proxy.go
@@ -312,28 +312,30 @@ func realMain() {
 
 	if err := setupLogger(logLevel); err != nil {
 		logger().WithError(err).Fatal("unable to setup logger")
+		os.Exit(1)
 	}
 
 	if err := printAgentLogs(agentLogsSocket); err != nil {
 		logger().WithError(err).Fatal("failed to print agent logs")
-		return
+		os.Exit(1)
 	}
 
 	muxAddr, err := unixAddr(channel)
 	if err != nil {
 		logger().WithError(err).Fatal("invalid mux socket address")
+		os.Exit(1)
 	}
 	listenAddr, err := unixAddr(proxyAddr)
 	if err != nil {
 		logger().WithError(err).Fatal("invalid listen socket address")
-		return
+		os.Exit(1)
 	}
 
 	// yamux connection
 	servConn, err := net.Dial("unix", muxAddr)
 	if err != nil {
 		logger().WithError(err).WithField("channel", muxAddr).Fatal("failed to dial channel")
-		return
+		os.Exit(1)
 	}
 	defer func() {
 		if servConn != nil {
@@ -345,7 +347,7 @@ func realMain() {
 	l, err := serve(servConn, "unix", listenAddr, results)
 	if err != nil {
 		logger().WithError(err).Fatal("failed to serve")
-		return
+		os.Exit(1)
 	}
 	defer func() {
 		if l != nil {
@@ -363,6 +365,7 @@ func realMain() {
 
 	if err := handleExitSignal(sigCh, &servConn, &l); err != nil {
 		logger().WithError(err).Fatal("failed to handle exit signal")
+		os.Exit(1)
 	}
 
 	logger().Debug("shutting down")

--- a/proxy.go
+++ b/proxy.go
@@ -136,9 +136,11 @@ func setupLogger(logLevel string) error {
 	proxyLog.Formatter = &logrus.TextFormatter{TimestampFormat: time.RFC3339Nano}
 
 	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO|syslog.LOG_USER, proxyName)
-	if err == nil {
-		proxyLog.AddHook(hook)
+	if err != nil {
+		return err
 	}
+
+	proxyLog.AddHook(hook)
 
 	logger().WithField("version", version).Info()
 

--- a/proxy.go
+++ b/proxy.go
@@ -121,7 +121,7 @@ func proxyConn(conn1 net.Conn, conn2 net.Conn, wg *sync.WaitGroup) {
 	copyStream := func(dst io.Writer, src io.Reader) {
 		_, err := io.Copy(dst, src)
 		if err != nil {
-			logger().Debug("Copy stream error: %v", err)
+			logger().WithError(err).Debug("Copy stream error")
 		}
 
 		once.Do(cleanup)

--- a/proxy.go
+++ b/proxy.go
@@ -125,7 +125,7 @@ func logger() *logrus.Entry {
 	})
 }
 
-func setupLogger(logLevel string) error {
+func setupLogger(logLevel string, announceFields logrus.Fields) error {
 	level, err := logrus.ParseLevel(logLevel)
 	if err != nil {
 		return err
@@ -142,7 +142,7 @@ func setupLogger(logLevel string) error {
 
 	proxyLog.AddHook(hook)
 
-	logger().WithField("version", version).Info()
+	logger().WithFields(announceFields).WithField("log-level", logLevel).Info("announce")
 
 	return nil
 }
@@ -312,7 +312,15 @@ func realMain() {
 
 	sigCh := setupNotifier()
 
-	if err := setupLogger(logLevel); err != nil {
+	announceFields := logrus.Fields{
+		"agent-logs-socket":   agentLogsSocket,
+		"channel-mux-socket":  channel,
+		"debug":               debug,
+		"proxy-listen-socket": proxyAddr,
+		"version":             version,
+	}
+
+	if err := setupLogger(logLevel, announceFields); err != nil {
 		logger().WithError(err).Fatal("unable to setup logger")
 		os.Exit(1)
 	}

--- a/proxy.go
+++ b/proxy.go
@@ -154,7 +154,7 @@ func printAgentLogs(sock string) error {
 
 	agentLogsAddr, err := unixAddr(sock)
 	if err != nil {
-		logger().WithField("socket-address", sock).Fatal("invalid agent logs socket address")
+		logger().WithField("socket-address", sock).WithError(err).Fatal("invalid agent logs socket address")
 		return err
 	}
 
@@ -188,7 +188,7 @@ func printAgentLogs(sock string) error {
 		}
 
 		if err := scanner.Err(); err != nil {
-			logger().Errorf("Failed reading agent logs from socket: %v", err)
+			logger().WithError(err).Error("Failed reading agent logs from socket")
 		}
 	}()
 
@@ -311,11 +311,11 @@ func realMain() {
 	sigCh := setupNotifier()
 
 	if err := setupLogger(logLevel); err != nil {
-		logger().Fatal(err)
+		logger().WithError(err).Fatal("unable to setup logger")
 	}
 
 	if err := printAgentLogs(agentLogsSocket); err != nil {
-		logger().Fatal(err)
+		logger().WithError(err).Fatal("failed to print agent logs")
 		return
 	}
 
@@ -325,14 +325,14 @@ func realMain() {
 	}
 	listenAddr, err := unixAddr(proxyAddr)
 	if err != nil {
-		logger().Fatal("invalid listen socket address")
+		logger().WithError(err).Fatal("invalid listen socket address")
 		return
 	}
 
 	// yamux connection
 	servConn, err := net.Dial("unix", muxAddr)
 	if err != nil {
-		logger().Fatalf("failed to dial channel(%q): %s", muxAddr, err)
+		logger().WithError(err).WithField("channel", muxAddr).Fatal("failed to dial channel")
 		return
 	}
 	defer func() {
@@ -344,7 +344,7 @@ func realMain() {
 	results := make(chan error)
 	l, err := serve(servConn, "unix", listenAddr, results)
 	if err != nil {
-		logger().Fatal(err)
+		logger().WithError(err).Fatal("failed to serve")
 		return
 	}
 	defer func() {
@@ -356,14 +356,13 @@ func realMain() {
 	go func() {
 		for err := range results {
 			if err != nil {
-				logger().Fatal(err)
+				logger().WithError(err).Fatal("channel error")
 			}
 		}
 	}()
 
 	if err := handleExitSignal(sigCh, &servConn, &l); err != nil {
-		logger().Fatal(err)
-		return
+		logger().WithError(err).Fatal("failed to handle exit signal")
 	}
 
 	logger().Debug("shutting down")

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -100,7 +100,7 @@ func client(proxyAddr, file string) error {
 	return <-copyCh
 }
 
-func server(listener net.Listener) error {
+func server(listener net.Listener, closeCh chan bool) error {
 	// Accept once
 	conn, err := listener.Accept()
 	if err != nil {
@@ -112,7 +112,11 @@ func server(listener net.Listener) error {
 	if err != nil {
 		return err
 	}
-	defer session.Close()
+
+	go func() {
+		<-closeCh
+		session.Close()
+	}()
 
 	for {
 		stream, err := session.Accept()
@@ -179,8 +183,9 @@ func TestProxy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	closeCh := make(chan bool)
 	go func() {
-		server(l)
+		server(l, closeCh)
 		l.Close()
 	}()
 
@@ -193,10 +198,15 @@ func TestProxy(t *testing.T) {
 	defer servConn.Close()
 
 	results := make(chan error)
-	_, err = serve(servConn, "unix", listenSock, results)
+	lp, s, err := serve(servConn, "unix", listenSock, results)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() {
+		close(closeCh)
+		lp.Close()
+		s.Close()
+	}()
 
 	// run client tests
 	files, err := ioutil.ReadDir(testDir)
@@ -205,23 +215,24 @@ func TestProxy(t *testing.T) {
 	}
 
 	wg := &sync.WaitGroup{}
+	cliRes := make(chan error)
 	for _, file := range files {
 		if file.IsDir() {
 			continue
 		}
 		wg.Add(1)
 		go func(filename string) {
-			results <- client(listenSock, filename)
+			cliRes <- client(listenSock, filename)
 			wg.Done()
 		}(file.Name())
 	}
 
 	go func() {
 		wg.Wait()
-		close(results)
+		close(cliRes)
 	}()
 
-	for err = range results {
+	for err := range cliRes {
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -204,13 +204,13 @@ func TestProxy(t *testing.T) {
 	}
 	defer func() {
 		close(closeCh)
-		lp.Close()
 		s.Close()
 	}()
 
 	// run client tests
 	files, err := ioutil.ReadDir(testDir)
 	if err != nil {
+		lp.Close()
 		t.Fatal(err)
 	}
 
@@ -232,11 +232,16 @@ func TestProxy(t *testing.T) {
 		close(cliRes)
 	}()
 
-	for err := range cliRes {
+	for err = range cliRes {
 		if err != nil {
 			t.Fatal(err)
 		}
 	}
+
+	// closing the listener should result in an error in results channel
+	lp.Close()
+	err = <-results
+	assert.NotNil(t, err, "closing listener should result in an error")
 }
 
 func TestSetupSigtermNotifier(t *testing.T) {


### PR DESCRIPTION
analyzed each patch from HEAD (6f209b7) to 1.1.0.

Analysis:
 1.1.1 | * 494d0d8 Makefile: Add DESTDIR variable support.

1.1.1 | * 7fd3734 logging: Fix incorrect logger usage

1.1.1 | * ec252d8 logging: Redirect yamux warnings/errors to logger

1.1.1 | * 1fbb8b3 proxy: wait copy goroutine to quit
1.1.1 | * 22c6f40 proxy: close yamux session properly

NO *   c416c9f Merge pull request #91 from sboeuf/introduce_heartbeat_yamux
| * 063d58f proxy: Maintain communication state with a heartbeat

NO   | * 1672418 logging: Add sandbox CLI option
1.1.1 | * 9b6bb05 logging: Display standard announce message
1.1.1 | * 246f707 CI: Update bash on Travis OSX for hashes

1.1.1 | * 73dbb10 logger: Die if unable to create syslog hook
1.1.1 | * 0cfa402 main: Exit on fatal error
1.1.1 | * 7681a94 logging: Use WithError() for all errors
 