### PR TITLE
Makefile: trigger build on VERSION file changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-$(TARGET): $(SOURCES)
+$(TARGET): $(SOURCES) $(VERSION_FILE)
 	go build -o $@ -ldflags "-X main.version=$(VERSION_COMMIT)"
 
 test:


### PR DESCRIPTION
If the VERSION file changes, rebuild.

This was found whilst switching between versions that had identical
sources, but not VERSION files.

Fixes: #121

Signed-off-by: Graham Whaley <graham.whaley@intel.com>