### PR TITLE
make: interpret LIBEXECDIR as an absolute path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,11 +5,11 @@
 #
 
 DESTDIR :=
-PREFIX := usr
-LIBEXECDIR := libexec
+PREFIX := /usr
+LIBEXECDIR := $(PREFIX)/libexec
 PROJECT := kata-containers
 # Override will ignore PREFIX, LIBEXECDIR and PROJECT
-INSTALLDIR := /$(PREFIX)/$(LIBEXECDIR)/$(PROJECT)
+INSTALLDIR := $(LIBEXECDIR)/$(PROJECT)
 
 TARGET = kata-proxy
 SOURCES := $(shell find . 2>&1 | grep -E '.*\.go$$')


### PR DESCRIPTION
Define and interpret LIBEXECDIR as an absolute path,
to be consistent with the commonly accepted way to define
it in GNU make projects.

Fixes: #125
