### PR TITLE
CI: add a CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,13 @@
+# Copyright 2019 Intel Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Define any code owners for this repository.
+# The code owners lists are used to help automatically enforce
+# reviews and acks of the right groups on the right PRs.
+
+# Order in this file is important. Only the last match will be
+# used. See https://help.github.com/articles/about-code-owners/
+
+*.md    @kata-containers/documentation
+


### PR DESCRIPTION
Add a CODEOWNERS file, explicitly listing the
@kata-containers/documentation group as the owners
of all *.md files.

This is used as part of the github 'review and ack' automated
process.

Fixes: #134

Signed-off-by: Graham Whaley <graham.whaley@intel.com>