### PR TITLE
docs: Add arch link to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,7 @@
 [![codecov](https://codecov.io/gh/kata-containers/proxy/branch/master/graph/badge.svg)](https://codecov.io/gh/kata-containers/proxy)
 
 # Kata Containers Proxy
+
+The `kata-proxy` is part of the Kata Containers project. For more information on how
+the `proxy` fits into the Kata Containers architecture, refer to the
+[Kata Containers architecture documentation](https://github.com/kata-containers/documentation/blob/master/architecture.md#proxy).


### PR DESCRIPTION
Add a link in the rather sparse top level proxy README
file off to the relevant architecture documentation.

Fixes: #136

Signed-off-by: Graham Whaley <graham.whaley@intel.com>