### PR TITLE
lint: Switch golang linter to golangci-lint

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -77,9 +77,9 @@ func client(proxyAddr, file string) error {
 	var result []byte
 	for {
 		if expected >= 1024 {
-			result = make([]byte, 1024, 1024)
+			result = make([]byte, 1024)
 		} else if expected > 0 {
-			result = make([]byte, expected, expected)
+			result = make([]byte, expected)
 		} else {
 			break
 		}


### PR DESCRIPTION
gometalinter is deprecated and will be archived April '19. The
suggestion is to switch to golangci-lint which is apparently 5x faster
than gometalinter.

Partially fixes: github.com/kata-containers/runtime#1377