### PR TITLE
travis: Update go version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ language: go
 go_import_path: github.com/kata-containers/proxy
 
 go:
-  - "1.10.x"
+  - "1.11.x"
 
 env:
   - target_branch=$TRAVIS_BRANCH


### PR DESCRIPTION
Update go version used in travis from 1.10 to 1.11

Fixes: #168.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>