### PR TITLE
CI: allow osx builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
     - os: linux
       sudo: required
       dist: trusty
+  allow_failures:
+    - os: osx
 
 language: go
 go_import_path: github.com/kata-containers/proxy


### PR DESCRIPTION
osx builds on travis are failing to find linux tools like getopt and
curl. Temporarily allowing them to fail while this is being worked out.

Fixes: #188

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>