### PR TITLE
Proxy: Socket file 'other' permission changes to support ACRN Hypervisor

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -239,7 +239,17 @@ func printAgentLogs(sock string) error {
 	otherMask := 0007
 	other := int(fileInfo.Mode().Perm()) & otherMask
 	if other != 0 {
-		return fmt.Errorf("All socket permissions for 'other' should be disabled, got %3.3o", other)
+		logger().Infof("All socket permissions for 'other' should be disabled, got %4.4o", int(fileInfo.Mode().Perm()))
+
+		// Setting permissions socket for "other" to 0.
+		otherMask := 0770
+		other := int(fileInfo.Mode().Perm()) & otherMask
+		err := os.Chmod(agentLogsAddr, os.FileMode(other))
+		if err != nil {
+			logger().Infof("Cannot change socket permissions for 'other' %d", err)
+		} else {
+			logger().Infof("Chaning socket permissions to %4.4o", other)
+		}
 	}
 
 	conn, err := net.Dial("unix", agentLogsAddr)


### PR DESCRIPTION
When binding the socket with the file path, the socket file permission
is changed to 755. The reason being the following,

Bind system call sets the socket file permission(mode) based on,
socket FD permission and umask bits set. Socket FD by default is
set to 777 and umask by default is set to 022. This results in 755.
ACRN doesn't plan to have an API to update the umask so added
the workaround in kata proxy, where if the ‘other’ permission
is not disabled, then kata proxy can override and disable it.

Fixes: #191

Signed-off-by: Vijay Dhanraj <vijay.dhanraj@intel.com>