### PR TITLE
ci: travis: use xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
   include:
     - os: linux
       sudo: required
-      dist: trusty
+      dist: xenial
   allow_failures:
     - os: osx
 


### PR DESCRIPTION
Instead of old trusty distribution.

Fixes: #224.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>