### PR TITLE
DNM: Do not run unit tests with podman CI

### DIFF
--- a/.ci/go-test.sh
+++ b/.ci/go-test.sh
@@ -8,4 +8,7 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+
+
 run_go_test
+


### PR DESCRIPTION
To setup the unit tests we need docker, that is why we are not going to
run unit tests with podman CI.

Fixes #234

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>