### PR TITLE
action: Trigger some actions on label

### DIFF
--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -10,10 +10,13 @@ on:
     types:
       - opened
       - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   move-linked-issues-to-in-progress:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     steps:
       - name: Install hub
         run: |

--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -16,6 +16,7 @@ on:
 jobs:
   check-pr-porting-labels:
     runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'safe-to-test')
     steps:
       - name: Install hub
         run: |


### PR DESCRIPTION
Change the following two GitHub actions (which operate on PRs) so that
they will only trigger once new PRs have been manually reviewed:

| GitHub Action | Summary | Reason `pull_request_target` event needed |
|-|-|-|
| `move-issues-to-in-progress.yaml` | Moves issues to the "In progress" column in the ["Issue backlog" project](https://github.com/orgs/kata-containers/projects/23). | Required to determine linked issue for a PR using the GitHub API. |
| `require-pr-porting-labels.yaml` | Performs checks on each PR to ensure they confirm to the [porting guidelines](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#porting). | Need access to a PRs labels. |

This change reduces the risk associated with a hypothetical "bad actor PR"
that tries to attack the repository or infrastructure by only triggering
the actions that need this elevated privilege event after the PR has
been sanity checked by a trusted community member. The community member
requests the two actions above run by applying the `safe-to-test` label.

# References

- http://lists.katacontainers.io/pipermail/kata-dev/2021-January/001691.html
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests

Fixes: #299.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>